### PR TITLE
story/VOGRE-12

### DIFF
--- a/annotations/templates/annotations/repository_collections_text_list.html
+++ b/annotations/templates/annotations/repository_collections_text_list.html
@@ -13,7 +13,7 @@
 <div class="container">
     <h1>{{ title }}{{ group_info.name }}</h1><br>
     <table class="table table-striped">
-        <thead>
+        <thead class="thead-dark">
             <tr>
                 <th>Title</th>
                 <th>Authors</th>
@@ -23,6 +23,7 @@
                 <th>URL</th>
                 <th>Date Added</th>
                 <th>Files</th>
+                <th>Actions</th>
             </tr>
         </thead>
         <tbody>
@@ -44,21 +45,28 @@
                 <td>{{ text.itemType }}</td>
                 <td>{{ text.volume|default:"N/A" }}</td>
                 <td>{{ text.pages|default:"N/A" }}</td>
+                <td>{{ text.url|default:"N/A" }}</td>
                 <td>{{ text.dateAdded }}</td>
                 <td>
-                    <button class="btn btn-info btn-sm" onclick="fetchFiles('{{ text.key }}')">
+                    {% if text.gilesUploads and text.gilesUploads|length > 0 %}
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark" viewBox="0 0 16 16">
+                        <path d="M14 4.5V14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h5.5zm-3 0A1.5 1.5 0 0 1 9.5 3V1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V4.5z"/>
+                    </svg>{% else %}{% endif %}
+                </td>
+                <td>
+                    <button class="btn btn-primary btn-sm" onclick="fetchFiles('{{ text.key }}')">
                         View Files
                     </button>
                 </td>
             </tr>
             <tr id="file-row-{{ text.key }}" style="display: none;">
-                <td colspan="8">
+                <td colspan="9">
                     <div class="file-list" id="file-list-{{ text.key }}"></div>
                 </td>
             </tr>
             {% empty %}
             <tr>
-                <td colspan="8">No texts available in this collection.</td>
+                <td colspan="9" class="text-center">No texts available in this collection.</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -72,10 +80,9 @@
         console.log("Fetching files for itemKey:", itemKey);
 
         // Clear any existing file information
-        fileListDiv.innerHTML = 'Loading...';
+        fileListDiv.innerHTML = 'Loading files...';
         fileRow.style.display = 'table-row';
 
-        
         const repositoryId = {{ repository.id }};
         const groupId = {{ group_id }};
         const url = `/repository/files/${repositoryId}/groups/${groupId}/items/${itemKey}/`;
@@ -89,27 +96,30 @@
         .then(response => response.json())
         .then(data => {
             console.log(data);
+
+            // Display files
             if (data.files && data.files.length > 0) {
-                let fileListHtml = '<table class="table table-bordered"><thead><tr><th>Filename</th><th>Content Type</th><th>Actions</th></tr></thead><tbody>';
+                let fileListHtml = '<ul class="list-group">';
                 data.files.forEach(file => {
-                    fileListHtml += `<tr>
-                        <td>${file.filename}</td>
-                        <td>${file.content_type}</td>
-                        <td>
-                            <a href="${file.url}" target="_blank" class="btn btn-sm btn-success">Download</a>
-                            <button class="btn btn-info btn-sm import-file" data-file-url="${file.url}" data-item-key="${itemKey}">Import</button>
-                        </td>
-                    </tr>`;
+                    fileListHtml += `<li class="list-group-item d-flex justify-content-between align-items-center">
+                        <span class="file-name">${file.filename}</span>
+                        <button class="btn btn-info btn-sm import-file" data-file-url="${file.url}" data-item-key="${itemKey}">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-cloud-arrow-down" viewBox="0 0 16 16">
+                            <path fill-rule="evenodd" d="M7.646 10.854a.5.5 0 0 0 .708 0l2-2a.5.5 0 0 0-.708-.708L8.5 9.293V5.5a.5.5 0 0 0-1 0v3.793L6.354 8.146a.5.5 0 1 0-.708.708z"/>
+                            <path d="M4.406 3.342A5.53 5.53 0 0 1 8 2c2.69 0 4.923 2 5.166 4.579C14.758 6.804 16 8.137 16 9.773 16 11.569 14.502 13 12.687 13H3.781C1.708 13 0 11.366 0 9.318c0-1.763 1.266-3.223 2.942-3.593.143-.863.698-1.723 1.464-2.383m.653.757c-.757.653-1.153 1.44-1.153 2.056v.448l-.445.049C2.064 6.805 1 7.952 1 9.318 1 10.785 2.23 12 3.781 12h8.906C13.98 12 15 10.988 15 9.773c0-1.216-1.02-2.228-2.313-2.228h-.5v-.5C12.188 4.825 10.328 3 8 3a4.53 4.53 0 0 0-2.941 1.1z"/>
+                            </svg>
+                        </button>
+                    </li>`;
                 });
-                fileListHtml += '</tbody></table>';
+                fileListHtml += '</ul>';
                 fileListDiv.innerHTML = fileListHtml;
             } else {
-                fileListDiv.innerHTML = 'No files available for this item.';
+                fileListDiv.innerHTML = '<div class="alert alert-warning">No files available for this item.</div>';
             }
         })
         .catch(error => {
             console.error('Error fetching files:', error);
-            fileListDiv.innerHTML = 'Failed to load files.';
+            fileListDiv.innerHTML = '<div class="alert alert-danger">Failed to load files.</div>';
         });
     }
 </script>

--- a/annotations/templates/annotations/repository_collections_text_list.html
+++ b/annotations/templates/annotations/repository_collections_text_list.html
@@ -11,9 +11,9 @@
 
 {% block main %}
 <div class="container">
-    <h1>{{ title }}{{ group_info.name }}</h1><br>
+    <h1>{{ title }} {{ group_info.name }}</h1><br>
     <table class="table table-striped">
-        <thead class="thead-dark">
+        <thead>
             <tr>
                 <th>Title</th>
                 <th>Authors</th>
@@ -45,7 +45,7 @@
                 <td>{{ text.itemType }}</td>
                 <td>{{ text.volume|default:"N/A" }}</td>
                 <td>{{ text.pages|default:"N/A" }}</td>
-                <td>{{ text.url|default:"N/A" }}</td>
+                <td><a href="{{ text.url|default:"#" }}" target="_blank">{{ text.url|default:"No URL" }}</a></td>
                 <td>{{ text.dateAdded }}</td>
                 <td>
                     {% if text.gilesUploads and text.gilesUploads|length > 0 %}
@@ -103,12 +103,7 @@
                 data.files.forEach(file => {
                     fileListHtml += `<li class="list-group-item d-flex justify-content-between align-items-center">
                         <span class="file-name">${file.filename}</span>
-                        <button class="btn btn-info btn-sm import-file" data-file-url="${file.url}" data-item-key="${itemKey}">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-cloud-arrow-down" viewBox="0 0 16 16">
-                            <path fill-rule="evenodd" d="M7.646 10.854a.5.5 0 0 0 .708 0l2-2a.5.5 0 0 0-.708-.708L8.5 9.293V5.5a.5.5 0 0 0-1 0v3.793L6.354 8.146a.5.5 0 1 0-.708.708z"/>
-                            <path d="M4.406 3.342A5.53 5.53 0 0 1 8 2c2.69 0 4.923 2 5.166 4.579C14.758 6.804 16 8.137 16 9.773 16 11.569 14.502 13 12.687 13H3.781C1.708 13 0 11.366 0 9.318c0-1.763 1.266-3.223 2.942-3.593.143-.863.698-1.723 1.464-2.383m.653.757c-.757.653-1.153 1.44-1.153 2.056v.448l-.445.049C2.064 6.805 1 7.952 1 9.318 1 10.785 2.23 12 3.781 12h8.906C13.98 12 15 10.988 15 9.773c0-1.216-1.02-2.228-2.313-2.228h-.5v-.5C12.188 4.825 10.328 3 8 3a4.53 4.53 0 0 0-2.941 1.1z"/>
-                            </svg>
-                        </button>
+                        <button class="btn btn-info btn-sm" onclick="importFile('${itemKey}', '${file.id}')">Import</button>
                     </li>`;
                 });
                 fileListHtml += '</ul>';
@@ -122,6 +117,39 @@
             fileListDiv.innerHTML = '<div class="alert alert-danger">Failed to load files.</div>';
         });
     }
+
+    function importFile(itemKey, fileId) {
+        const repositoryId = {{ repository.id }};
+        const groupId = {{ group_id }};
+        const url = `/repository/${repositoryId}/group/${groupId}/text/${itemKey}/files/${fileId}/`;
+    
+        fetch(url, {
+            method: 'POST',
+            headers: {
+                'X-CSRFToken': '{{ csrf_token }}',
+                'Content-Type': 'application/json'
+            },
+        })
+        .then(response => {
+            if (!response.ok) {
+                return response.json().then(data => {
+                    throw new Error(data.error || 'Unexpected error occurred');
+                });
+            }
+            return response.json();
+        })
+        .then(data => {
+            if (data.success) {
+                window.location.href = data.redirect_url;
+            } else {
+                console.error('Failed to import the file');
+            }
+        })
+        .catch(error => {
+            console.error('Error importing file:', error);
+        });
+    }
+    
 </script>
 
 {% endblock %}

--- a/annotations/templates/annotations/repository_collections_text_list.html
+++ b/annotations/templates/annotations/repository_collections_text_list.html
@@ -99,11 +99,16 @@
 
             // Display files
             if (data.files && data.files.length > 0) {
-                let fileListHtml = '<ul class="list-group">';
+                let fileListHtml = '<ul style="list-style-type: none; padding: 0;">';
                 data.files.forEach(file => {
-                    fileListHtml += `<li class="list-group-item d-flex justify-content-between align-items-center">
-                        <span class="file-name">${file.filename}</span>
-                        <button class="btn btn-info btn-sm" onclick="importFile('${itemKey}', '${file.id}')">Import</button>
+                    fileListHtml += `
+                    <li style="display: flex; justify-content: space-between; align-items: center; padding: 10px; margin-bottom: 5px; border: 1px solid #ddd; border-radius: 4px;">
+                        <span style="font-size: 14px;">${file.filename}</span>
+                        <button class="btn btn-primary btn-sm" onclick="importFile('${itemKey}', '${file.id}')">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" style="vertical-align: middle;">
+                                <path fill-rule="evenodd" d="M8 0a5.53 5.53 0 0 0-3.594 1.342c-.766.66-1.321 1.52-1.464 2.383C1.266 4.095 0 5.555 0 7.318 0 9.366 1.708 11 3.781 11H7.5V5.5a.5.5 0 0 1 1 0V11h4.188C14.502 11 16 9.57 16 7.773c0-1.636-1.242-2.969-2.834-3.194C12.923 1.999 10.69 0 8 0m-.354 15.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 14.293V11h-1v3.293l-2.146-2.147a.5.5 0 0 0-.708.708z"/>
+                            </svg>
+                        </button>
                     </li>`;
                 });
                 fileListHtml += '</ul>';

--- a/annotations/templates/annotations/repository_collections_text_list.html
+++ b/annotations/templates/annotations/repository_collections_text_list.html
@@ -8,6 +8,7 @@
 <a href="{% url "repository_collections" repository.id %}{% if project_id %}?project_id={{ project_id }}{% endif %}" class="btn btn-xs">Collections</a>&raquo;
 <a href="{% url "repository_collection" repository.id group_id %}{% if project_id %}?project_id={{ project_id }}{% endif %}" class="btn btn-xs">{{ group_info.name }}</a>
 {% endblock %}
+
 {% block main %}
 <div class="container">
     <h1>{{ title }}{{ group_info.name }}</h1><br>
@@ -22,7 +23,6 @@
                 <th>URL</th>
                 <th>Date Added</th>
                 <th>Files</th>
-                <th>Actions</th>
             </tr>
         </thead>
         <tbody>
@@ -44,13 +44,16 @@
                 <td>{{ text.itemType }}</td>
                 <td>{{ text.volume|default:"N/A" }}</td>
                 <td>{{ text.pages|default:"N/A" }}</td>
-                <td><a href="{{ text.url|default:"#" }}" target="_blank">{{ text.url|default:"No URL" }}</a></td>
                 <td>{{ text.dateAdded }}</td>
-                <td>{% if text.gilesUploads and text.gilesUploads|length > 0 %}<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark" viewBox="0 0 16 16">
-                    <path d="M14 4.5V14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h5.5zm-3 0A1.5 1.5 0 0 1 9.5 3V1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V4.5z"/>
-                  </svg>{% else %}{% endif %}</td>
                 <td>
-                    <a href="{% url "repository_text_import" repository.id group_id text.key %}{% if project_id %}?project_id={{ project_id }}{% endif %}" class="btn btn-info">Import</a>
+                    <button class="btn btn-info btn-sm" onclick="fetchFiles('{{ text.key }}')">
+                        View Files
+                    </button>
+                </td>
+            </tr>
+            <tr id="file-row-{{ text.key }}" style="display: none;">
+                <td colspan="8">
+                    <div class="file-list" id="file-list-{{ text.key }}"></div>
                 </td>
             </tr>
             {% empty %}
@@ -61,4 +64,54 @@
         </tbody>
     </table>
 </div>
+
+<script>
+    function fetchFiles(itemKey) {
+        const fileListDiv = document.getElementById(`file-list-${itemKey}`);
+        const fileRow = document.getElementById(`file-row-${itemKey}`);
+        console.log("Fetching files for itemKey:", itemKey);
+
+        // Clear any existing file information
+        fileListDiv.innerHTML = 'Loading...';
+        fileRow.style.display = 'table-row';
+
+        
+        const repositoryId = {{ repository.id }};
+        const groupId = {{ group_id }};
+        const url = `/repository/files/${repositoryId}/groups/${groupId}/items/${itemKey}/`;
+
+        fetch(url, {
+            method: 'GET',
+            headers: {
+                'X-CSRFToken': '{{ csrf_token }}'
+            }
+        })
+        .then(response => response.json())
+        .then(data => {
+            console.log(data);
+            if (data.files && data.files.length > 0) {
+                let fileListHtml = '<table class="table table-bordered"><thead><tr><th>Filename</th><th>Content Type</th><th>Actions</th></tr></thead><tbody>';
+                data.files.forEach(file => {
+                    fileListHtml += `<tr>
+                        <td>${file.filename}</td>
+                        <td>${file.content_type}</td>
+                        <td>
+                            <a href="${file.url}" target="_blank" class="btn btn-sm btn-success">Download</a>
+                            <button class="btn btn-info btn-sm import-file" data-file-url="${file.url}" data-item-key="${itemKey}">Import</button>
+                        </td>
+                    </tr>`;
+                });
+                fileListHtml += '</tbody></table>';
+                fileListDiv.innerHTML = fileListHtml;
+            } else {
+                fileListDiv.innerHTML = 'No files available for this item.';
+            }
+        })
+        .catch(error => {
+            console.error('Error fetching files:', error);
+            fileListDiv.innerHTML = 'Failed to load files.';
+        });
+    }
+</script>
+
 {% endblock %}

--- a/annotations/views/repository_views.py
+++ b/annotations/views/repository_views.py
@@ -18,6 +18,8 @@ from annotations.models import Text, TextCollection
 from annotations.annotators import supported_content_types
 from annotations.tasks import tokenize
 
+from django.http import JsonResponse
+
 from urllib.parse import urlparse, parse_qs
 from urllib.parse import urlencode
 from external_accounts.utils import parse_iso_datetimes
@@ -250,6 +252,24 @@ def repository_collection_texts(request, repository_id, group_id, group_collecti
     }
 
     return render(request, 'annotations/repository_collections_text_list.html', context)
+
+@citesphere_authenticated
+def repository_text_files(request, repository_id, group_id, item_id):
+    """View to fetch and display files for a specific text item."""
+    user = request.user
+    repository = get_object_or_404(Repository, pk=repository_id)
+    manager = RepositoryManager(user=user, repository=repository)
+
+    try:
+        item_data = manager.item_files(group_id, item_id)
+    except Exception as e:
+        return JsonResponse({'error': str(e)}, status=500)
+
+    return JsonResponse({
+        'item': item_data['item']['details'],
+        'files': item_data['item']['files']
+    })
+
 
 @citesphere_authenticated
 def repository_text_import(request, repository_id, group_id, text_key):

--- a/annotations/views/repository_views.py
+++ b/annotations/views/repository_views.py
@@ -255,7 +255,7 @@ def repository_collection_texts(request, repository_id, group_id, group_collecti
 
 @citesphere_authenticated
 def repository_text_files(request, repository_id, group_id, item_id):
-    """View to fetch and display files for a specific text item."""
+    """View to fetch and return a dictionary of files for a specific text item."""
     user = request.user
     repository = get_object_or_404(Repository, pk=repository_id)
     manager = RepositoryManager(user=user, repository=repository)
@@ -266,10 +266,8 @@ def repository_text_files(request, repository_id, group_id, item_id):
         return JsonResponse({'error': str(e)}, status=500)
 
     return JsonResponse({
-        'item': item_data['item']['details'],
-        'files': item_data['item']['files']
+        'files': item_data.get('files', [])
     })
-
 
 @citesphere_authenticated
 def repository_text_import(request, repository_id, group_id, text_key):

--- a/vogon/urls.py
+++ b/vogon/urls.py
@@ -133,6 +133,12 @@ urlpatterns = [
     re_path(r'^repository/(?P<repository_id>[0-9]+)/$', views.repository_views.repository_details, name='repository_details'),
     re_path(r'^repository/(?P<repository_id>[0-9]+)/text/(?P<text_id>[0-9]+)/project/(?P<project_id>[0-9]+)/$', views.repository_views.repository_text_add_to_project, name='repository_text_add_to_project'),
 
+    re_path(r'^repository/files/(?P<repository_id>[0-9]+)/groups/(?P<group_id>[0-9]+)/items/(?P<item_id>[a-zA-Z0-9]+)/$', 
+            views.repository_views.repository_text_files, 
+            name='repository_text_files'),
+
+
+
     re_path(r'^repository/$', views.repository_views.repository_list, name='repository_list'),
 
     re_path(r'^text/(?P<text_id>[0-9]+)/public/$', views.text_views.text_public, name='text_public'),

--- a/vogon/urls.py
+++ b/vogon/urls.py
@@ -128,16 +128,11 @@ urlpatterns = [
     re_path(r'^repository/(?P<repository_id>[0-9]+)/search/$', views.repository_views.repository_search, name='repository_search'),
     re_path(r'^repository/(?P<repository_id>[0-9]+)/collections/(?P<group_id>[0-9]+)/$', views.repository_views.repository_collection, name='repository_collection'),
     re_path(r'^repository/(?P<repository_id>[0-9]+)/collection/(?P<group_id>[0-9]+)/group-collection/(?P<group_collection_id>[a-zA-Z0-9]+)/texts/$', views.repository_views.repository_collection_texts, name='repository_collections_text_list'),
-    re_path(r'^repository/(?P<repository_id>[0-9]+)/group/(?P<group_id>[a-zA-Z0-9]+)/text/(?P<text_key>[a-zA-Z0-9]+)/$', views.repository_views.repository_text_import, name='repository_text_import'),
+    re_path(r'^repository/(?P<repository_id>[0-9]+)/group/(?P<group_id>[a-zA-Z0-9]+)/text/(?P<text_key>[a-zA-Z0-9]+)/files/(?P<file_id>[a-zA-Z0-9]+)/$', views.repository_views.repository_text_import, name='repository_text_import'),
     re_path(r'^repository/(?P<repository_id>[0-9]+)/text/(?P<text_id>[0-9]+)/content/(?P<content_id>[0-9]+)/$', views.repository_views.repository_text_content, name='repository_text_content'),
     re_path(r'^repository/(?P<repository_id>[0-9]+)/$', views.repository_views.repository_details, name='repository_details'),
     re_path(r'^repository/(?P<repository_id>[0-9]+)/text/(?P<text_id>[0-9]+)/project/(?P<project_id>[0-9]+)/$', views.repository_views.repository_text_add_to_project, name='repository_text_add_to_project'),
-
-    re_path(r'^repository/files/(?P<repository_id>[0-9]+)/groups/(?P<group_id>[0-9]+)/items/(?P<item_id>[a-zA-Z0-9]+)/$', 
-            views.repository_views.repository_text_files, 
-            name='repository_text_files'),
-
-
+    re_path(r'^repository/files/(?P<repository_id>[0-9]+)/groups/(?P<group_id>[0-9]+)/items/(?P<item_id>[a-zA-Z0-9]+)/$', views.repository_views.repository_text_files, name='repository_text_files'),
 
     re_path(r'^repository/$', views.repository_views.repository_list, name='repository_list'),
 


### PR DESCRIPTION
# Guidelines for Pull Requests

If you haven't yet read our code review guidelines, please do so, You can find them [here](https://diging.atlassian.net/wiki/spaces/DIGING/pages/2256076801/Code+Review+Guidelines).

Please confirm the following by adding an x for each item (turn `[ ]` into `[x]`).

- [x] I have removed all code style changes that are not necessary (e.g. changing blanks across the whole file that don’t need to be changed, adding empty lines in parts other than your own code)
- [x] I am not making any changes to files that don’t have any effect (e.g. imports added that don’t need to be added)
- [x] I do not have any sysout statements in my code or commented out code that isn’t needed anymore
- [x] I am not reformatting any files in the wrong format or without cause. 
- [x] I am not changing file encoding or line endings to something else than UTF-8, LF
- [x] My pull request does not show an insane amount of files being changed although my ticket only requires a few files being changed
- [ ] I have added Javadoc/documentation where appropriate
- [x] I have added test cases where appropriate
- [x] I have explained any part of my code/implementation decisions that is not be self-explanatory

## Please provide a brief description of your ticket 
This ticket requires to show the user all files associated with a specific text in citesphere and allow the user to import any inidivudal file the user would like.

# Multiple texts for a Citesphere entry

Description:
Citesphere entries can have more than one text attached to them (right now I think the first one will be used?).
The text table should list all the file names that are attached to a record, and then instead of an “Import”  button, there should be an import icon next to each file.

https://diging.atlassian.net/browse/VOGRE-12?atlOrigin=eyJpIjoiNWJjMWNmMGJiYWYyNDdmMzkyYmIyZWMyMGZiMTA0MTEiLCJwIjoiaiJ9

## Are there any other pull requests that this one depends on?
No
  
## Anything else the reviewer needs to know?

I Updated the `repository_text_import` view to support file-specific imports by using `file_id` as part of the unique identifier (`uri`). This change ensures that each file import, even for the same `text_key`, creates or updates a distinct `Text` object. The view now returns `JsonResponse`, providing error messages and a `redirect_url` for successful imports, since now all files are being rendered via AJAX. 
