### PR TITLE
bug/VOGRE-50

### DIFF
--- a/repository/managers.py
+++ b/repository/managers.py
@@ -232,6 +232,8 @@ class RepositoryManager:
 
         # Extract Giles uploads and their text if available
         text = get_giles_document_details(self.user, fileId)
+        if text is None:
+            raise IOError("The file you're trying to import doesn't exist. Please try another file.")
         item_data['item']['text'] = text
 
         item_data['item']['details'] = item_details

--- a/repository/managers.py
+++ b/repository/managers.py
@@ -234,7 +234,7 @@ class RepositoryManager:
         text = get_giles_document_details(self.user, fileId)
         if text is None:
             raise IOError("The file you're trying to import doesn't exist. Please try another file.")
-        item_data['item']['text'] = text
 
+        item_data['item']['text'] = text
         item_data['item']['details'] = item_details
         return item_data


### PR DESCRIPTION
# Guidelines for Pull Requests

If you haven't yet read our code review guidelines, please do so, You can find them [here](https://diging.atlassian.net/wiki/spaces/DIGING/pages/2256076801/Code+Review+Guidelines).

Please confirm the following by adding an x for each item (turn `[ ]` into `[x]`).

- [x] I have removed all code style changes that are not necessary (e.g. changing blanks across the whole file that don’t need to be changed, adding empty lines in parts other than your own code)
- [x] I am not making any changes to files that don’t have any effect (e.g. imports added that don’t need to be added)
- [x] I do not have any sysout statements in my code or commented out code that isn’t needed anymore
- [x] I am not reformatting any files in the wrong format or without cause. 
- [x] I am not changing file encoding or line endings to something else than UTF-8, LF
- [x] My pull request does not show an insane amount of files being changed although my ticket only requires a few files being changed
- [x] I have added Javadoc/documentation where appropriate
- [x] I have added test cases where appropriate
- [x] I have explained any part of my code/implementation decisions that is not be self-explanatory

## Please provide a brief description of your ticket 
Getting Giles text extraction error when adding texts to projects on the production server

https://github.com/diging/vogon-resuscitate/issues/40

Let’s change the error message here to make clear the file is just not there.

[VOGRE-50](https://diging.atlassian.net/browse/VOGRE-50?atlOrigin=eyJpIjoiNGRmM2M1ODZjZDA1NDRmNjhmY2M4YmRkNzU1MzRlOWEiLCJwIjoiaiJ9)


## Are there any other pull requests that this one depends on?
No
  
## Anything else the reviewer needs to know?

Citesphere in Production is behind in commits than develop, but I have made relevant changes in develop as well.


[VOGRE-50]: https://diging.atlassian.net/browse/VOGRE-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ